### PR TITLE
fix: link download zip file

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,7 +10,7 @@ After select the package, you can choose the dependency type (tagged version, br
 
 #### Install manually
 
-Download using the [GitHub .zip download](https://github.com/dracula/swiftui/master.zip) option and unzip them.
+Download using the [GitHub .zip download](https://github.com/dracula/swiftui/archive/refs/heads/master.zip) option and unzip them.
 
 Copy `Dracula.swift` and `Colors.xcassets` to your project's folder.
 


### PR DESCRIPTION
### Current condition

URL to download zip file in installation instruction result in not found page.

<img width="1376" alt="Jepretan Layar 2022-03-28 pukul 9 31 47 PM" src="https://user-images.githubusercontent.com/3760093/160421559-15a2b191-ddcb-4d4b-ac0d-e24536da4560.png">

<img width="1376" alt="Jepretan Layar 2022-03-28 pukul 9 26 18 PM" src="https://user-images.githubusercontent.com/3760093/160420369-2e1779bd-d422-4157-9c93-9a90fcc007fc.png">

### Proposed solution

Change the URL with the same URL from manually download zip file.

<img width="1376" alt="Jepretan Layar 2022-03-28 pukul 9 30 27 PM" src="https://user-images.githubusercontent.com/3760093/160421169-bcb1a0eb-e661-4698-8ef8-d922792b6599.png">


